### PR TITLE
Node 0.10 以降に対応

### DIFF
--- a/mecab.cc
+++ b/mecab.cc
@@ -87,7 +87,7 @@ private:
 			uv_default_loop(),
 			req,
 			MeCab_parser::AsyncWork,
-			MeCab_parser::AsyncAfter
+			(uv_after_work_cb)MeCab_parser::AsyncAfter
 		);
 
 		return scope.Close( Undefined() );


### PR DESCRIPTION
取り急ぎ `uv_queue_work()` の第四引数を `uv_after_work_cb` にキャストしました。
