### PR TITLE
メモリリークを修正

### DIFF
--- a/mecab.cc
+++ b/mecab.cc
@@ -166,6 +166,9 @@ private:
 
 		Local<Value> argv[2] = { String::New(""), result_arr };
 		callback->Call(Context::GetCurrent()->Global(), 2, argv);
+
+		callback.Dispose();
+		callback.Clear();
 	}
 
 	// JavaScript の世界で parse したら呼ばれる（同期版）


### PR DESCRIPTION
非同期処理のコールバックが開放されずメモリリークが発生していたのを修正しました。
