### PR TITLE
コマンドラインに渡す文字列をエスケープ

### DIFF
--- a/mecab.js
+++ b/mecab.js
@@ -1,5 +1,6 @@
 var exec     = require('child_process').exec;
 var execSync = require('execsync');
+var sq       = require('shell-quote');
 
 // for backward compatibility
 var MeCab = function() {};
@@ -27,6 +28,9 @@ MeCab.prototype = {
 		});
 		return result;
 	},
+    _shellCommand : function(str) {
+        return sq.quote(['echo', str]) + ' | mecab';
+    },
 	_parseMeCabResult : function(result) {
 		return result.split('\n').map(function(line) {
 			return line.replace('\t', ',').split(',');
@@ -34,14 +38,14 @@ MeCab.prototype = {
 	},
 	parse : function(str, callback) {
 		process.nextTick(function() { // for bug
-			exec('echo "' + str + '" | mecab', function(err, result) {
+			exec(MeCab._shellCommand(str), function(err, result) {
 				if (err) { return callback(err); }
 				callback(err, MeCab._parseMeCabResult(result).slice(0,-2));
 			});
 		});
 	},
 	parseSync : function(str) {
-		var result = execSync('echo ' + str + ' | mecab');
+		var result = execSync(MeCab._shellCommand(str));
 		return MeCab._parseMeCabResult(result).slice(0, -2);
 	},
 	parseFormat : function(str, callback) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "main": "mecab",
   "dependencies": {
-	  "execsync": "*"
+    "execsync": "*",
+    "shell-quote": "*"
   },
   "readmeFilename": "README.md",
   "description": "Asynchronous japanese morphological analyzer using MeCab.",

--- a/test.js
+++ b/test.js
@@ -1,30 +1,40 @@
 var MeCab = new require('./mecab.js');
-var testWord = 'すもももももももものうち';
 
-// 非同期版
-MeCab.parse(testWord, function(err, result) {
-	if (err) throw err;
-	console.log('非同期:\n', result);
-});
+runAllFeatures('すもももももももものうち');
 
-// 非同期版
-MeCab.wakachi(testWord, function(err, result) {
-	if (err) throw err;
-	console.log('非同期（わかち書き）:\n', result);
-});
+runPartialFeature('\'"\\');
+runPartialFeature('&\necho abc');
+runPartialFeature('abc | cat');
 
-// 非同期版
-MeCab.parseFormat(testWord, function(err, result) {
-	if (err) throw err;
-	console.log('非同期（フォーマット整形）:\n', result);
-});
+function runAllFeatures(testWord) {
+    // 非同期版
+    MeCab.parse(testWord, function (err, result) {
+        if (err) throw err;
+        console.log('非同期:\n', result);
+    });
 
-// 同期版
-console.log('同期:\n', MeCab.parseSync(testWord) );
+    // 非同期版
+    MeCab.wakachi(testWord, function (err, result) {
+        if (err) throw err;
+        console.log('非同期（わかち書き）:\n', result);
+    });
 
-// 同期版
-console.log('同期（わかち書き）:\n', MeCab.wakachiSync(testWord) );
+    // 非同期版
+    MeCab.parseFormat(testWord, function (err, result) {
+        if (err) throw err;
+        console.log('非同期（フォーマット整形）:\n', result);
+    });
 
-// 同期版
-console.log('同期（フォーマット整形）:\n', MeCab.parseSyncFormat(testWord) );
+    // 同期版
+    console.log('同期:\n', MeCab.parseSync(testWord));
 
+    // 同期版
+    console.log('同期（わかち書き）:\n', MeCab.wakachiSync(testWord));
+
+    // 同期版
+    console.log('同期（フォーマット整形）:\n', MeCab.parseSyncFormat(testWord));
+}
+
+function runPartialFeature(testWord) {
+    console.log("わかち書き " + testWord + " :\n", MeCab.wakachiSync(testWord));
+}


### PR DESCRIPTION
特定の文字を含む文字列をパースしようとすると、実行されるシェルコマンド文字列がおかしくなってしまいました。OSコマンドインジェクションの危険性もあります。
