### PR TITLE
use sync-exec instead of execSync

### DIFF
--- a/mecab.js
+++ b/mecab.js
@@ -1,5 +1,5 @@
 var exec     = require('child_process').exec;
-var execSync = require('execsync');
+var execSync = require('sync-exec');
 var sq       = require('shell-quote');
 
 // for backward compatibility

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "mecab",
   "dependencies": {
-    "execsync": "*",
+    "sync-exec": "*",
     "shell-quote": "*"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
execSync is no longer maintained.

```
THIS PROJECT IS NO LONGER MAINTAINED. Please seek other alternatives.

the project cannot be updated on npm due to camelCased title
i no longer do Windows
both iojs and node.js v0.12 have execSync function
older node users can try sync-exec from npm (suggested by one of the commentors)
```
See also
  - https://github.com/gvarsanyi/sync-exec/blob/master/README.md
  - https://github.com/mgutz/execSync/issues/38
