### PR TITLE
Add support for child_process.execSync

### DIFF
--- a/mecab.js
+++ b/mecab.js
@@ -1,5 +1,5 @@
 var exec     = require('child_process').exec;
-var execSync = require('execsync');
+var execSync = require('child_process').execSync;
 var sq       = require('shell-quote');
 
 // for backward compatibility
@@ -47,7 +47,7 @@ MeCab.prototype = {
     },
     parseSync : function(str) {
         var result = execSync(MeCab._shellCommand(str));
-        return MeCab._parseMeCabResult(result).slice(0, -2);
+        return MeCab._parseMeCabResult(String(result)).slice(0, -2);
     },
     parseFormat : function(str, callback) {
         MeCab.parse(str, function(err, result) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "main": "mecab",
   "dependencies": {
-    "execsync": "*",
     "shell-quote": "*"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
`execsync` module is outdated and actually did causing build error.
Use of `child_process.execSync` is more straightforward way.

`child_process.execSync` was added since Node __v0.12.0__([release note](http://blog.nodejs.org/2015/02/06/node-v0-12-0-stable/)).