### PR TITLE
単語にカンマ「,」が含まれていると結果がおかしくなるのを修正

### DIFF
--- a/mecab.js
+++ b/mecab.js
@@ -34,12 +34,12 @@ MeCab.prototype = {
     },
     _parseMeCabResult : function(result) {
         return result.split('\n').map(function(line) {
-            var word = line.split('\t');
+            var arr = line.split('\t');
             // EOS
-            if (word.length === 1) {
+            if (arr.length === 1) {
                 return [line];
             }
-            return [word[0]].concat(word[1].split(','));
+            return [arr[0]].concat(arr[1].split(','));
         });
     },
     parse : function(str, callback) {

--- a/mecab.js
+++ b/mecab.js
@@ -34,7 +34,12 @@ MeCab.prototype = {
     },
     _parseMeCabResult : function(result) {
         return result.split('\n').map(function(line) {
-            return line.replace('\t', ',').split(',');
+            var word = line.split('\t');
+            // EOS
+            if (word.length === 1) {
+                return [line];
+            }
+            return [word[0]].concat(word[1].split(','));
         });
     },
     parse : function(str, callback) {


### PR DESCRIPTION
単語にカンマ「,」が含まれている場合に、パース結果がおかしくなってしまう問題を修正しました。
